### PR TITLE
refactor: Remove 'REFUNDED' status from order and payment models

### DIFF
--- a/client/src/pages/admin/Orders.jsx
+++ b/client/src/pages/admin/Orders.jsx
@@ -46,7 +46,6 @@ const statusColors = {
     SHIPPING: "bg-indigo-100 text-indigo-800",
     COMPLETED: "bg-green-100 text-green-800",
     CANCELLED: "bg-red-100 text-red-800",
-    REFUNDED: "bg-emerald-100 text-emerald-800",
     FAILED: "bg-red-100 text-red-800",
 };
 

--- a/client/src/pages/customer/MyOrders.jsx
+++ b/client/src/pages/customer/MyOrders.jsx
@@ -10,13 +10,21 @@ const statusOptions = [
   { key: 'SHIPPING', label: 'Đang giao' },
   { key: 'COMPLETED', label: 'Hoàn thành' },
   { key: 'CANCELLED', label: 'Đã hủy' },
-  { key: 'REFUNDED', label: 'Hoàn tiền' },
 ];
 
 const formatCurrency = (v) => new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(v || 0);
 const formatDate = (d) => new Date(d).toLocaleString('vi-VN');
 
 const StatusBadge = ({ status }) => {
+  const statusLabels = {
+    PENDING: 'Chờ xử lý',
+    CONFIRMED: 'Đã xác nhận',
+    SHIPPING: 'Đang giao',
+    COMPLETED: 'Hoàn thành',
+    CANCELLED: 'Đã hủy',
+    FAILED: 'Thất bại',
+  };
+  
   const map = {
     PENDING: 'bg-yellow-100 text-yellow-800',
     CONFIRMED: 'bg-blue-100 text-blue-800',
@@ -24,10 +32,14 @@ const StatusBadge = ({ status }) => {
     SHIPPING: 'bg-purple-100 text-purple-800',
     COMPLETED: 'bg-green-100 text-green-800',
     CANCELLED: 'bg-red-100 text-red-800',
-    REFUNDED: 'bg-emerald-100 text-emerald-800',
     FAILED: 'bg-red-100 text-red-800',
   };
-  return <span className={`px-2 py-1 text-xs font-semibold rounded-full ${map[status] || 'bg-gray-100 text-gray-800'}`}>{status || 'N/A'}</span>;
+  
+  return (
+    <span className={`px-2 py-1 text-xs font-semibold rounded-full ${map[status] || 'bg-gray-100 text-gray-800'}`}>
+      {statusLabels[status] || status || 'N/A'}
+    </span>
+  );
 };
 
 const MyOrders = () => {

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -308,33 +308,21 @@ notificationSchema.statics.createOrderNotification = async function (
     PROCESSING: 'Đơn hàng đang được xử lý',
     SHIPPING: 'Đơn hàng đang được giao',
     COMPLETED: 'Đơn hàng đã giao thành công',
-    CANCELLED: 'Đơn hàng đã bị hủy',
-    REFUNDED: 'Đơn hàng đã được hoàn tiền'
+    CANCELLED: 'Đơn hàng đã bị hủy'
   };
-
-  // Chỉ những status này mới gửi EMAIL
-  const shouldSendEmail = ['PENDING', 'SHIPPING', 'COMPLETED', 'CANCELLED'].includes(status);
 
   const data = {
     userId,
     type: 'ORDER_UPDATE',
-    priority: ['CANCELLED', 'REFUNDED'].includes(status) ? 'HIGH' : 'MEDIUM',
+    priority: status === 'CANCELLED' ? 'HIGH' : 'MEDIUM',
     title: titles[status] || 'Cập nhật đơn hàng',
     message,
     relatedId: orderId,
     relatedType: 'order',
     actionUrl: `/orders/${orderId}`,
     actionText: 'Xem chi tiết',
-    channels: shouldSendEmail ? ['IN_APP', 'EMAIL'] : ['IN_APP'],
+    channels: ['IN_APP'], // Chỉ thông báo trong app, không gửi email
   };
-
-  if (shouldSendEmail) {
-    data.emailData = {
-      subject: titles[status] || 'Cập nhật đơn hàng',
-      templateName: `order-${status.toLowerCase()}`,
-      templateData: new Map([['orderId', orderId.toString()]])
-    };
-  }
 
   return this.createNotification(data);
 };

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -80,7 +80,6 @@ const orderSchema = new mongoose.Schema(
         'SHIPPING',
         'COMPLETED',
         'CANCELLED',
-        'REFUNDED',
         'FAILED'
       ],
       default: 'PENDING'
@@ -251,7 +250,7 @@ orderSchema.methods.updateStatus = async function (newStatus, note = '', updated
 
 // Method to cancel order
 orderSchema.methods.cancelOrder = async function (reason, cancelledBy) {
-  if (['COMPLETED', 'CANCELLED', 'REFUNDED'].includes(this.status)) {
+  if (['COMPLETED', 'CANCELLED'].includes(this.status)) {
     throw new Error('Không thể hủy đơn hàng này');
   }
   

--- a/server/models/Payment.js
+++ b/server/models/Payment.js
@@ -24,7 +24,6 @@ const paymentSchema = new mongoose.Schema(
         'PROCESSING',
         'COMPLETED',
         'FAILED',
-        'REFUNDED',
         'CANCELLED'
       ],
       default: 'PENDING_PAYMENT'
@@ -172,26 +171,6 @@ paymentSchema.methods.markAsFailed = async function (reason) {
   this.status = 'FAILED';
   this.failureReason = reason;
   this.processedAt = new Date();
-  
-  await this.save();
-  
-  return this;
-};
-
-// Method to process refund
-paymentSchema.methods.processRefund = async function (amount, reason) {
-  if (this.status !== 'COMPLETED') {
-    throw new Error('Chỉ có thể hoàn tiền cho giao dịch đã hoàn thành');
-  }
-  
-  if (amount > this.amount) {
-    throw new Error('Số tiền hoàn không được vượt quá số tiền gốc');
-  }
-  
-  this.status = 'REFUNDED';
-  this.refundAmount = amount;
-  this.refundReason = reason;
-  this.refundedAt = new Date();
   
   await this.save();
   


### PR DESCRIPTION
Eliminated the 'REFUNDED' status from order and payment schemas, related UI components, and notification logic. Refund processing methods and references to 'REFUNDED' have been removed to simplify status handling and notification channels.