### PR TITLE
Remove comment from notification type

### DIFF
--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -19,7 +19,7 @@ const notificationSchema = new mongoose.Schema(
         'SYSTEM_ANNOUNCEMENT',
         'WELCOME',
         'PASSWORD_RESET',
-        'NEW_ORDER_ADMIN'  // ✅ Thêm type mới cho admin
+        'NEW_ORDER_ADMIN'
       ],
       required: true
     },


### PR DESCRIPTION
Deleted an inline comment from the 'NEW_ORDER_ADMIN' notification type in the Notification schema for cleaner code.