### PR TITLE
Update shipping fee calculation to 14% of subtotal

### DIFF
--- a/client/src/redux/slices/cartSlice.js
+++ b/client/src/redux/slices/cartSlice.js
@@ -91,7 +91,8 @@ const calculateSummary = (items) => {
     }
   });
   
-  const shippingFee = subtotal >= 500000 ? 0 : 30000;
+  // Shipping fee = 14% of subtotal (rounded)
+  const shippingFee = Math.round(subtotal * 0.14);
   return {
     totalItems,
     subtotal,

--- a/server/services/promotionService.js
+++ b/server/services/promotionService.js
@@ -471,8 +471,9 @@ class PromotionService {
     const minOrderValue = promotion.conditions?.minOrderValue || 0;
     
     if (cartTotal >= minOrderValue) {
-      // Return a standard shipping fee amount or the actual shipping fee from cart
-      return cart.shippingFee || 30000; // Default 30k VND shipping fee
+      // Calculate shipping fee as 14% of subtotal if not provided
+      const shippingFee = cart.shippingFee || Math.round(cartTotal * 0.14);
+      return shippingFee;
     }
 
     return 0;


### PR DESCRIPTION
Changed shipping fee logic in both cartSlice and promotionService to calculate the fee as 14% of the subtotal, rounded. This replaces the previous fixed or conditional fee approach for consistency across client and server.