### PR TITLE
Implement tiered shipping fee calculation

### DIFF
--- a/client/src/pages/customer/Checkout.jsx
+++ b/client/src/pages/customer/Checkout.jsx
@@ -9,6 +9,7 @@ import addressService from '../../services/addressService';
 import api from '../../services/api';
 import { toast } from 'react-toastify';
 import Swal from 'sweetalert2';
+import { calculateShippingFee } from '../../utils/shippingCalculator';
 import CouponDropdown from '../../components/checkout/CouponDropdown';
 
 // ==================== Edit Address Modal Component ====================
@@ -837,7 +838,7 @@ const Checkout = () => {
     total: preview.totalPrice,
   } : {
     subtotal: summary.subtotal,
-    shippingFee: Math.round(summary.subtotal * 0.14), // 14% of subtotal
+    shippingFee: calculateShippingFee(summary.subtotal), // Bậc thang: 14%, 8%, 5%, 3%, 1.8%
     discount: 0,
     hasCoupons: hasCoupons,
     selectedCoupons: selectedCoupons,

--- a/client/src/redux/slices/cartSlice.js
+++ b/client/src/redux/slices/cartSlice.js
@@ -1,5 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import * as cartService from '../../services/cartService';
+import { calculateShippingFee } from '../../utils/shippingCalculator';
 import { logout } from './authSlice'; // Import logout action từ authSlice
 
 // Async thunks
@@ -91,8 +92,8 @@ const calculateSummary = (items) => {
     }
   });
   
-  // Shipping fee = 14% of subtotal (rounded)
-  const shippingFee = Math.round(subtotal * 0.14);
+  // Shipping fee theo bậc thang (14%, 8%, 5%, 3%, 1.8%)
+  const shippingFee = calculateShippingFee(subtotal);
   return {
     totalItems,
     subtotal,

--- a/client/src/utils/shippingCalculator.js
+++ b/client/src/utils/shippingCalculator.js
@@ -1,0 +1,57 @@
+/**
+ * Calculate shipping fee based on tiered pricing
+ * @param {Number} subtotal - Tạm tính (VND)
+ * @returns {Number} Phí vận chuyển (VND)
+ */
+export const calculateShippingFee = (subtotal) => {
+  if (subtotal < 100000) {
+    // < 100k: 14%
+    return Math.round(subtotal * 0.14);
+  } else if (subtotal < 300000) {
+    // 100k - 300k: 8%
+    return Math.round(subtotal * 0.08);
+  } else if (subtotal < 600000) {
+    // 300k - 600k: 5%
+    return Math.round(subtotal * 0.05);
+  } else if (subtotal < 1000000) {
+    // 600k - 1M: 3%
+    return Math.round(subtotal * 0.03);
+  } else {
+    // >= 1M: 1.8%
+    return Math.round(subtotal * 0.018);
+  }
+};
+
+/**
+ * Get shipping fee percentage based on subtotal
+ * @param {Number} subtotal - Tạm tính (VND)
+ * @returns {Number} Percentage (0.14, 0.08, etc.)
+ */
+export const getShippingPercentage = (subtotal) => {
+  if (subtotal < 100000) return 0.14;
+  if (subtotal < 300000) return 0.08;
+  if (subtotal < 600000) return 0.05;
+  if (subtotal < 1000000) return 0.03;
+  return 0.018;
+};
+
+/**
+ * Get shipping tier info for display
+ * @param {Number} subtotal - Tạm tính (VND)
+ * @returns {Object} { percentage, nextTier, nextTierThreshold }
+ */
+export const getShippingTierInfo = (subtotal) => {
+  if (subtotal < 100000) {
+    return { percentage: 14, nextTier: 8, nextTierThreshold: 100000 };
+  } else if (subtotal < 300000) {
+    return { percentage: 8, nextTier: 5, nextTierThreshold: 300000 };
+  } else if (subtotal < 600000) {
+    return { percentage: 5, nextTier: 3, nextTierThreshold: 600000 };
+  } else if (subtotal < 1000000) {
+    return { percentage: 3, nextTier: 1.8, nextTierThreshold: 1000000 };
+  } else {
+    return { percentage: 1.8, nextTier: null, nextTierThreshold: null };
+  }
+};
+
+export default calculateShippingFee;

--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -8,6 +8,7 @@ import { StatusCodes } from 'http-status-codes';
 import { BadRequestError, NotFoundError, UnauthorizedError } from '../utils/errorHandler.js';
 import mongoose from 'mongoose';
 import Stripe from 'stripe';
+import { calculateShippingFee } from '../utils/shippingCalculator.js';
 
 import { buildVNPayUrl, verifyVNPayReturn } from '../services/vnpayService.js';
 import { getTempOrder, removeTempOrder } from '../utils/tempOrderStorage.js';
@@ -283,7 +284,7 @@ const previewOrder = async (req, res) => {
     subtotal += itemSubtotal;
   }
 
-  let shippingFee = Math.round(subtotal * 0.14); // 14% of subtotal
+  let shippingFee = calculateShippingFee(subtotal); // Bậc thang: 14%, 8%, 5%, 3%, 1.8%
 
   // Xử lý mã giảm giá
   let discount = 0;

--- a/server/services/cartService.js
+++ b/server/services/cartService.js
@@ -1,5 +1,6 @@
 import Cart from '../models/Cart.js';
 import Product from '../models/Product.js';
+import { calculateShippingFee } from '../utils/shippingCalculator.js';
 import { BadRequestError, NotFoundError } from '../utils/errorHandler.js';
 
 /**
@@ -37,8 +38,8 @@ class CartService {
       }
     });
     
-    // Shipping fee = 14% of subtotal (rounded)
-    const shippingFee = Math.round(subtotal * 0.14);
+    // Shipping fee theo bậc thang (14%, 8%, 5%, 3%, 1.8%)
+    const shippingFee = calculateShippingFee(subtotal);
     
     return {
       totalItems,

--- a/server/services/orderService.js
+++ b/server/services/orderService.js
@@ -9,6 +9,7 @@ import { BadRequestError, NotFoundError, UnauthorizedError } from '../utils/erro
 import { buildVNPayUrl, verifyVNPayReturn } from './vnpayService.js';
 import cacheService from './cacheService.js';
 import { storeTempOrder } from '../utils/tempOrderStorage.js';
+import { calculateShippingFee } from '../utils/shippingCalculator.js';
 
 /**
  * Order Service
@@ -135,8 +136,8 @@ class OrderService {
         subtotal += itemSubtotal;
       }
 
-      // Calculate fees - 14% of subtotal
-      const shippingFee = Math.round(subtotal * 0.14);
+      // Calculate shipping fee theo bậc thang (14%, 8%, 5%, 3%, 1.8%)
+      const shippingFee = calculateShippingFee(subtotal);
       let discount = 0;
       let promotionId = null;
       let promotionIds = [];
@@ -506,7 +507,7 @@ class OrderService {
       subtotal += itemSubtotal;
     }
 
-    const shippingFee = Math.round(subtotal * 0.14); // 14% of subtotal
+    const shippingFee = calculateShippingFee(subtotal); // Bậc thang: 14%, 8%, 5%, 3%, 1.8%
     let discount = 0;
     let promotionDetails = null;
 

--- a/server/services/promotionService.js
+++ b/server/services/promotionService.js
@@ -471,8 +471,8 @@ class PromotionService {
     const minOrderValue = promotion.conditions?.minOrderValue || 0;
     
     if (cartTotal >= minOrderValue) {
-      // Calculate shipping fee as 14% of subtotal if not provided
-      const shippingFee = cart.shippingFee || Math.round(cartTotal * 0.14);
+      // Calculate shipping fee theo bậc thang if not provided
+      const shippingFee = cart.shippingFee || calculateShippingFee(cartTotal);
       return shippingFee;
     }
 

--- a/server/utils/shippingCalculator.js
+++ b/server/utils/shippingCalculator.js
@@ -1,0 +1,55 @@
+/**
+ * Calculate shipping fee based on tiered pricing
+ * @param {Number} subtotal - Tạm tính (VND)
+ * @returns {Number} Phí vận chuyển (VND)
+ */
+export const calculateShippingFee = (subtotal) => {
+  if (subtotal < 100000) {
+    // < 100k: 14%
+    return Math.round(subtotal * 0.14);
+  } else if (subtotal < 300000) {
+    // 100k - 300k: 8%
+    return Math.round(subtotal * 0.08);
+  } else if (subtotal < 600000) {
+    // 300k - 600k: 5%
+    return Math.round(subtotal * 0.05);
+  } else if (subtotal < 1000000) {
+    // 600k - 1M: 3%
+    return Math.round(subtotal * 0.03);
+  } else {
+    // >= 1M: 1.8%
+    return Math.round(subtotal * 0.018);
+  }
+};
+
+/**
+ * Get shipping fee percentage based on subtotal
+ * @param {Number} subtotal - Tạm tính (VND)
+ * @returns {Number} Percentage (0.14, 0.08, etc.)
+ */
+export const getShippingPercentage = (subtotal) => {
+  if (subtotal < 100000) return 0.14;
+  if (subtotal < 300000) return 0.08;
+  if (subtotal < 600000) return 0.05;
+  if (subtotal < 1000000) return 0.03;
+  return 0.018;
+};
+
+/**
+ * Get shipping tier info for display
+ * @param {Number} subtotal - Tạm tính (VND)
+ * @returns {Object} { percentage, nextTier, nextTierThreshold }
+ */
+export const getShippingTierInfo = (subtotal) => {
+  if (subtotal < 100000) {
+    return { percentage: 14, nextTier: 8, nextTierThreshold: 100000 };
+  } else if (subtotal < 300000) {
+    return { percentage: 8, nextTier: 5, nextTierThreshold: 300000 };
+  } else if (subtotal < 600000) {
+    return { percentage: 5, nextTier: 3, nextTierThreshold: 600000 };
+  } else if (subtotal < 1000000) {
+    return { percentage: 3, nextTier: 1.8, nextTierThreshold: 1000000 };
+  } else {
+    return { percentage: 1.8, nextTier: null, nextTierThreshold: null };
+  }
+};


### PR DESCRIPTION
Replaced fixed 14% shipping fee logic with a tiered calculation (14%, 8%, 5%, 3%, 1.8%) based on subtotal in both client and server code. Added reusable shippingCalculator utility to client and server for consistent fee computation.