### PR TITLE
Remove product stock update logic from createOrder

### DIFF
--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -144,37 +144,7 @@ const createOrder = async (req, res) => {
 
       subtotal += itemSubtotal;
 
-      // *** FIX: Cập nhật stock bằng updateOne để tránh validation ***
-      if (product.hasVariants && selectedVariant) {
-        // Update variant stock
-        await Product.updateOne(
-          { 
-            _id: product._id,
-            'variants._id': selectedVariant._id
-          },
-          {
-            $inc: { 
-              'variants.$.stock': -item.quantity,
-              soldCount: item.quantity 
-            }
-          }
-          // { session } // Disabled for standalone MongoDB
-        );
-      } else {
-        // Update product stock
-        await Product.updateOne(
-          { _id: product._id },
-          {
-            $inc: { 
-              stock: -item.quantity,
-              soldCount: item.quantity 
-            }
-          }
-          // { session } // Disabled for standalone MongoDB
-        );
-      }
-      
-      console.log(`Product ${product.name} stock updated`);
+     
     }
 
     console.log('Order items prepared:', orderItems.length);


### PR DESCRIPTION
Eliminated code responsible for updating product and variant stock during order creation. This may be in preparation for refactoring stock management or moving it to another part of the application.