### PR TITLE
Invalidate product cache after stock updates

### DIFF
--- a/server/services/orderService.js
+++ b/server/services/orderService.js
@@ -345,6 +345,9 @@ class OrderService {
             }
           );
         }
+        
+        // ✅ Invalidate product cache after stock update
+        await cacheService.invalidateProduct(product._id);
       }
       
       // Create order


### PR DESCRIPTION
Added cache invalidation for products after stock changes in order cancellation, VNPay return, simulated VNPay payment, and order creation. This ensures product data remains consistent and up-to-date after inventory modifications.