### PR TITLE
Add orderId to review creation and validation

### DIFF
--- a/client/src/redux/slices/reviewSlice.js
+++ b/client/src/redux/slices/reviewSlice.js
@@ -17,13 +17,14 @@ export const fetchReviews = createAsyncThunk(
 // Gửi đánh giá mới
 export const createReview = createAsyncThunk(
   "reviews/createReview",
-  async ({ productId, rating, title, comment }, { rejectWithValue }) => {
+  async ({ productId, rating, title, comment, orderId }, { rejectWithValue }) => {
     try {
       const response = await reviewService.createReview({
         productId,
         rating,
         title,
-        comment
+        comment,
+        orderId
       });
       return response.review;
     } catch (err) {

--- a/server/services/reviewService.js
+++ b/server/services/reviewService.js
@@ -41,8 +41,9 @@ class ReviewService {
         throw new BadRequestError('Đơn hàng không hợp lệ hoặc chưa hoàn thành.');
       }
       
-      // Check if already reviewed for this order
+      // Check if already reviewed for this specific order
       const existingReview = await Review.findOne({ userId, productId, orderId });
+      
       if (existingReview) {
         throw new BadRequestError('Bạn đã đánh giá sản phẩm này trong đơn hàng này rồi.');
       }


### PR DESCRIPTION
The review creation flow now includes orderId, allowing reviews to be associated with specific orders. The service checks for existing reviews for the same product and order to prevent duplicate submissions.